### PR TITLE
Add middleware support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to `PhxJsonRpc` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.4.0] - 2023-04-20
+
+## Added
+
+- Middleware interface and macro (handles request before dispatching to the rpc controller)
 
 ### Changed
 
-- Bump ex_doc from 0.29.0 to 0.29.1
+- `Router.handle` now accepts second optional parameter: `meta_data`
+- Bump credo from 1.6.7 to 1.7.0
+- Bump dialyxir from 1.2.0 to 1.3.0
+- Bump excoveralls from 0.15.0 to 0.16.1
+- Bump ex_doc from 0.29.0 to 0.29.4
 
 ## [0.3.8] - 2022-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Middleware interface and macro (handles request before dispatching to the rpc controller)
+- Middleware interface and macro (handles requests before dispatching to the rpc controller)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ by adding `phx_json_rpc` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:phx_json_rpc, "~> 0.3.8"}
+    {:phx_json_rpc, "~> 0.4.0"}
   ]
 end
 ```

--- a/lib/phx_json_rpc.ex
+++ b/lib/phx_json_rpc.ex
@@ -13,7 +13,7 @@ defmodule PhxJsonRpc do
   Add `:phx_json_rpc` to your dependencies
 
   ```
-  {:phx_json_rpc, "~> 0.3.8"}
+  {:phx_json_rpc, "~> 0.4.0"}
   ```
 
   ## Usage with phoenix

--- a/lib/phx_json_rpc.ex
+++ b/lib/phx_json_rpc.ex
@@ -36,6 +36,10 @@ defmodule PhxJsonRpc do
 
     alias MyAppRpc.PetController
 
+    ## Middleware group (optional)
+    # Uncomment the line below, when neccessary (see `PhxJsonRpc.Router.Middleware` for usage)
+    # middleware([AuthMiddleware])
+
     ## Pet's service
     rpc("pet.create", PetController, :create, "#/components/schemas/Pet")
     rpc("pet.list", PetController, :list, "#/components/schemas/Pets")

--- a/lib/phx_json_rpc.ex
+++ b/lib/phx_json_rpc.ex
@@ -80,7 +80,9 @@ defmodule PhxJsonRpc do
     alias MyApp.Rpc.Router
 
     def rpc(conn, request) do
-      response = Router.handle(request)
+      # Handles rpc requests
+      # The second parameter is optional and used to share current context
+      response = Router.handle(request, conn)
       render(conn, "response.json", response)
     end
   end

--- a/lib/phx_json_rpc/logger.ex
+++ b/lib/phx_json_rpc/logger.ex
@@ -1,0 +1,19 @@
+defmodule PhxJsonRpc.Logger do
+  @moduledoc """
+  Module represents error logging functions.
+  """
+
+  require Logger
+
+  @doc """
+    Log exception linked with specific request ID.
+  """
+  def log_error(request_id, exception, stacktrace) do
+    Logger.error(
+      Enum.join([
+        "Request #{request_id} causes an exception: ",
+        Exception.format(:error, exception, stacktrace)
+      ])
+    )
+  end
+end

--- a/lib/phx_json_rpc/router.ex
+++ b/lib/phx_json_rpc/router.ex
@@ -68,6 +68,7 @@ defmodule PhxJsonRpc.Router do
 
       Module.register_attribute(__MODULE__, :json_schema, accumulate: false)
       Module.register_attribute(__MODULE__, :routes, accumulate: true)
+      Module.register_attribute(__MODULE__, :middleware, accumulate: false)
 
       @json_schema SchemaResolver.resolve(unquote(schema))
       @version unquote(version)
@@ -129,6 +130,21 @@ defmodule PhxJsonRpc.Router do
     end
   end
 
+  @doc """
+  Keeps user-defined middleware.
+
+  ## Arguments
+    * `middleware_group` - enumeration of the list of the middleware modules.
+
+  ## Examples
+      middleware(MyMiddlewareOne, MyMiddlewareTwo)
+  """
+  defmacro middleware(middleware_group) do
+    quote do
+      @middleware unquote(middleware_group)
+    end
+  end
+
   defmacro __before_compile__(_env) do
     quote do
       if Enum.empty?(@routes), do: raise(ArgumentError, message: "No routes specified.")
@@ -169,6 +185,10 @@ defmodule PhxJsonRpc.Router do
       @impl true
       def get_otp_app do
         @otp_app
+      end
+
+      def get_middleware do
+        @middleware
       end
 
       def handle(requests, meta_data \\ nil) do

--- a/lib/phx_json_rpc/router.ex
+++ b/lib/phx_json_rpc/router.ex
@@ -188,6 +188,7 @@ defmodule PhxJsonRpc.Router do
         @otp_app
       end
 
+      @impl true
       def get_middleware do
         @middleware
       end

--- a/lib/phx_json_rpc/router.ex
+++ b/lib/phx_json_rpc/router.ex
@@ -171,8 +171,9 @@ defmodule PhxJsonRpc.Router do
         @otp_app
       end
 
-      def handle(requests) do
-        DefaultPipe.handle(requests, __MODULE__)
+      def handle(requests, meta_data \\ nil) do
+        ctx_instance = Context.build(__MODULE__, meta_data)
+        DefaultPipe.handle(requests, ctx_instance)
       end
     end
   end

--- a/lib/phx_json_rpc/router.ex
+++ b/lib/phx_json_rpc/router.ex
@@ -145,6 +145,7 @@ defmodule PhxJsonRpc.Router do
     end
   end
 
+  # credo:disable-for-next-line
   defmacro __before_compile__(_env) do
     quote do
       if Enum.empty?(@routes), do: raise(ArgumentError, message: "No routes specified.")

--- a/lib/phx_json_rpc/router.ex
+++ b/lib/phx_json_rpc/router.ex
@@ -134,7 +134,7 @@ defmodule PhxJsonRpc.Router do
   Keeps user-defined middleware.
 
   ## Arguments
-    * `middleware_group` - enumeration of the list of the middleware modules.
+    * `middleware_group` - enumeration of the list of middleware modules.
 
   ## Examples
       middleware(MyMiddlewareOne, MyMiddlewareTwo)

--- a/lib/phx_json_rpc/router/context.ex
+++ b/lib/phx_json_rpc/router/context.ex
@@ -22,6 +22,11 @@ defmodule PhxJsonRpc.Router.Context do
   """
   @type route_list :: list({atom(), MetaData.t()})
 
+  @typedoc """
+  Type represents the list of user-defined middleware.
+  """
+  @type middleware_list :: list(module())
+
   @doc """
   Returns the pre-defined list of routes.
   """
@@ -46,6 +51,11 @@ defmodule PhxJsonRpc.Router.Context do
   Returns the otp application name.
   """
   @callback get_otp_app() :: atom()
+
+  @doc """
+  Returns the middleware group.
+  """
+  @callback get_middleware() :: middleware_list()
 
   @doc """
   Builds new context.

--- a/lib/phx_json_rpc/router/context.ex
+++ b/lib/phx_json_rpc/router/context.ex
@@ -3,6 +3,18 @@ defmodule PhxJsonRpc.Router.Context do
   Context that provides access to the stored route list, jsonrpc version and schema.
   """
 
+  defstruct [:instance, :meta_data]
+
+  @typedoc """
+  Type represents structure for the rpc context.
+  - :instance is typically the self-link
+  - :meta_data, if present, is a map, containing user-defined params
+  """
+  @type t :: %__MODULE__{
+          instance: module(),
+          meta_data: map() | nil
+        }
+
   alias PhxJsonRpc.Router.MetaData
 
   @typedoc """
@@ -34,4 +46,23 @@ defmodule PhxJsonRpc.Router.Context do
   Returns the otp application name.
   """
   @callback get_otp_app() :: atom()
+
+  @doc """
+  Builds new context.
+
+  ## Examples
+
+      iex> PhxJsonRpc.Router.Context.build(Context, %{"hello" => "world"})
+      %PhxJsonRpc.Router.Context{
+        instance: Context,
+        meta_data: %{"hello" => "world"}
+      }
+  """
+  @spec build(module(), map() | nil) :: t
+  def build(instance, meta_data \\ nil) do
+    %__MODULE__{
+      instance: instance,
+      meta_data: meta_data
+    }
+  end
 end

--- a/lib/phx_json_rpc/router/context.ex
+++ b/lib/phx_json_rpc/router/context.ex
@@ -52,10 +52,10 @@ defmodule PhxJsonRpc.Router.Context do
 
   ## Examples
 
-      iex> PhxJsonRpc.Router.Context.build(Context, %{"hello" => "world"})
+      iex> PhxJsonRpc.Router.Context.build(Context, %{"is_rpc" => true})
       %PhxJsonRpc.Router.Context{
         instance: Context,
-        meta_data: %{"hello" => "world"}
+        meta_data: %{"is_rpc" => true}
       }
   """
   @spec build(module(), map() | nil) :: t

--- a/lib/phx_json_rpc/router/dispatcher.ex
+++ b/lib/phx_json_rpc/router/dispatcher.ex
@@ -18,8 +18,6 @@ defmodule PhxJsonRpc.Router.DefaultDispatcher do
 
   @behaviour PhxJsonRpc.Router.Dispatcher
 
-  require Logger
-
   alias PhxJsonRpc.Error.{
     InternalError,
     InvalidParams,
@@ -29,6 +27,7 @@ defmodule PhxJsonRpc.Router.DefaultDispatcher do
     ServerError
   }
 
+  alias PhxJsonRpc.Logger
   alias PhxJsonRpc.Response
   alias PhxJsonRpc.Router.MetaData
 
@@ -70,22 +69,13 @@ defmodule PhxJsonRpc.Router.DefaultDispatcher do
       with_error(%InternalError{}, id, version, e, __STACKTRACE__)
   end
 
-  defp log_error(request_id, exception, stacktrace) do
-    Logger.error(
-      Enum.join([
-        "Request #{request_id} causes an exception: ",
-        Exception.format(:error, exception, stacktrace)
-      ])
-    )
-  end
-
   defp with_result(result, id, version) do
     Response.new(data: result, id: id, valid?: true, version: version)
   end
 
   defp with_error(error, id, version, should_be_logged_error \\ nil, stacktrace \\ nil) do
     if should_be_logged_error do
-      log_error(id, should_be_logged_error, stacktrace)
+      Logger.log_error(id, should_be_logged_error, stacktrace)
     end
 
     Response.new(id: id, valid?: false, error: error, version: version)

--- a/lib/phx_json_rpc/router/middleware.ex
+++ b/lib/phx_json_rpc/router/middleware.ex
@@ -57,11 +57,11 @@ defmodule PhxJsonRpc.Router.DefaultMiddleware do
 
   def handle_middleware_group(middleware_group, request, context)
       when is_list(middleware_group) do
-    Enum.reduce(middleware_group, %{}, fn middleware, acc ->
-      if request.valid? do
-        middleware.handle(request, context)
+    Enum.reduce(middleware_group, request, fn middleware, req ->
+      if req.valid? do
+        middleware.handle(req, context)
       else
-        request
+        req
       end
     end)
   rescue

--- a/lib/phx_json_rpc/router/middleware.ex
+++ b/lib/phx_json_rpc/router/middleware.ex
@@ -1,0 +1,13 @@
+defmodule PhxJsonRpc.Router.Middleware do
+  @moduledoc """
+  Middleware interface for the group of routes.
+  """
+
+  alias PhxJsonRpc.Request
+  alias PhxJsonRpc.Router.Context
+
+  @doc """
+  Handles request before it will be dispatched to the controller.
+  """
+  @callback handle(request :: Request.t(), context :: Context.t()) :: Request.t()
+end

--- a/lib/phx_json_rpc/router/middleware.ex
+++ b/lib/phx_json_rpc/router/middleware.ex
@@ -1,7 +1,38 @@
 defmodule PhxJsonRpc.Router.Middleware do
   @moduledoc """
   Middleware interface for the group of routes.
+
+  Request must have `:valid => true` for passing through the next middleware.
+
+  ### Example
+
+      defmodule AuthMiddleware do
+        use PhxJsonRpc.Router.Middleware
+
+        @impl true
+        def handle(request, context) do
+          if context.meta_data.is_authenticated
+            request
+          else
+            request
+            |> Map.put(:valid?, false)
+            |> Map.put(:error, %AuthError{})
+          end
+        end
+      end
+
+      defmodule AuthError do
+        use PhxJsonRpc.Error,
+          message: "Unauthenticated",
+          code: -32_000
+      end
   """
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour PhxJsonRpc.Router.Middleware
+    end
+  end
 
   alias PhxJsonRpc.Request
   alias PhxJsonRpc.Router.Context

--- a/lib/phx_json_rpc/router/middleware.ex
+++ b/lib/phx_json_rpc/router/middleware.ex
@@ -11,3 +11,35 @@ defmodule PhxJsonRpc.Router.Middleware do
   """
   @callback handle(request :: Request.t(), context :: Context.t()) :: Request.t()
 end
+
+defmodule PhxJsonRpc.Router.DefaultMiddleware do
+  @moduledoc false
+
+  alias PhxJsonRpc.Error.InternalError
+
+  def handle(request, context) do
+    middleware_group = context.instance.get_middleware()
+
+    handle_middleware_group(middleware_group, request, context)
+  end
+
+  def handle_middleware_group(middleware_group, request, context)
+      when is_list(middleware_group) do
+    Enum.reduce(middleware_group, %{}, fn middleware, acc ->
+      if request.valid? do
+        middleware.handle(request, context)
+      else
+        request
+      end
+    end)
+  rescue
+    e ->
+      request
+      |> Map.put(:valid?, false)
+      |> Map.put(:error, %InternalError{message: Exception.format(:error, e)})
+  end
+
+  def handle_middleware_group(_, request, context) do
+    request
+  end
+end

--- a/lib/phx_json_rpc/router/middleware.ex
+++ b/lib/phx_json_rpc/router/middleware.ex
@@ -16,6 +16,7 @@ defmodule PhxJsonRpc.Router.DefaultMiddleware do
   @moduledoc false
 
   alias PhxJsonRpc.Error.InternalError
+  alias PhxJsonRpc.Logger
 
   def handle(request, context) do
     middleware_group = context.instance.get_middleware()
@@ -34,6 +35,8 @@ defmodule PhxJsonRpc.Router.DefaultMiddleware do
     end)
   rescue
     e ->
+      Logger.log_error(request.id, e, __STACKTRACE__)
+
       request
       |> Map.put(:valid?, false)
       |> Map.put(:error, %InternalError{message: Exception.format(:error, e)})

--- a/lib/phx_json_rpc/router/middleware.ex
+++ b/lib/phx_json_rpc/router/middleware.ex
@@ -73,7 +73,7 @@ defmodule PhxJsonRpc.Router.DefaultMiddleware do
       |> Map.put(:error, %InternalError{message: Exception.format(:error, e)})
   end
 
-  def handle_middleware_group(_, request, context) do
+  def handle_middleware_group(_, request, _context) do
     request
   end
 end

--- a/lib/phx_json_rpc/router/pipe.ex
+++ b/lib/phx_json_rpc/router/pipe.ex
@@ -41,7 +41,7 @@ defmodule PhxJsonRpc.Router.DefaultPipe do
 
   @impl true
   def handle(requests, context) when is_list(requests) do
-    if Enum.count(requests) <= context.get_max_batch_size() do
+    if Enum.count(requests) <= context.instance.get_max_batch_size() do
       handle_batch(requests, context)
     else
       show_limit_error()
@@ -53,14 +53,14 @@ defmodule PhxJsonRpc.Router.DefaultPipe do
     meta = get_metadata(request, context)
     schema_ref = if is_nil(meta), do: nil, else: meta.schema_ref
 
-    config = Application.get_env(context.get_otp_app(), context, [])
+    config = Application.get_env(context.instance.get_otp_app(), context, [])
     parser = config[:parser] || @default_parser
     validator = config[:validator] || @default_validator
     dispatcher = config[:dispatcher] || @default_dispatcher
 
     request
-    |> parser.parse(context.get_version())
-    |> validator.validate(schema_ref, context.get_json_schema())
+    |> parser.parse(context.instance.get_version())
+    |> validator.validate(schema_ref, context.instance.get_json_schema())
     |> dispatcher.dispatch(meta)
   end
 
@@ -80,7 +80,7 @@ defmodule PhxJsonRpc.Router.DefaultPipe do
     method = Map.get(request, "method")
 
     if is_binary(method) do
-      Keyword.get(context.get_routes(), get_key(method))
+      Keyword.get(context.instance.get_routes(), get_key(method))
     else
       nil
     end

--- a/mix.exs
+++ b/mix.exs
@@ -130,7 +130,9 @@ defmodule PhxJsonRpc.MixProject do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/phx_json_rpc_web/controllers"]
+  defp elixirc_paths(:test),
+    do: ["lib", "test/phx_json_rpc_web/controllers", "test/phx_json_rpc_web/middleware"]
+
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule PhxJsonRpc.MixProject do
   def project do
     [
       app: :phx_json_rpc,
-      version: "0.3.8",
+      version: "0.4.0",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule PhxJsonRpc.MixProject do
 
   alias PhxJsonRpc.Router.{
     Context,
+    Middleware,
     Parser,
     Validator,
     Dispatcher,
@@ -107,6 +108,7 @@ defmodule PhxJsonRpc.MixProject do
           Context,
           Parser,
           Validator,
+          Middleware,
           Dispatcher,
           SchemaResolver,
           Pipe

--- a/test/phx_json_rpc/middleware_test.exs
+++ b/test/phx_json_rpc/middleware_test.exs
@@ -1,8 +1,9 @@
 defmodule PhxJsonRpc.Router.MiddlewareTest do
   use ExUnit.Case
-  alias PhxJsonRpc.Router.Middleware
+
   alias PhxJsonRpc.Error.InternalError
   alias PhxJsonRpc.{Request, Response}
+  alias PhxJsonRpc.Router.Middleware
   alias PhxJsonRpcWeb.{TestController, TestMiddleware}
 
   use PhxJsonRpc.Router,

--- a/test/phx_json_rpc/middleware_test.exs
+++ b/test/phx_json_rpc/middleware_test.exs
@@ -2,8 +2,7 @@ defmodule PhxJsonRpc.Router.MiddlewareTest do
   use ExUnit.Case
 
   alias PhxJsonRpc.Error.InternalError
-  alias PhxJsonRpc.{Request, Response}
-  alias PhxJsonRpc.Router.Middleware
+  alias PhxJsonRpc.Response
   alias PhxJsonRpcWeb.{TestController, TestMiddleware}
 
   use PhxJsonRpc.Router,

--- a/test/phx_json_rpc/middleware_test.exs
+++ b/test/phx_json_rpc/middleware_test.exs
@@ -1,0 +1,52 @@
+defmodule PhxJsonRpc.Router.MiddlewareTest do
+  use ExUnit.Case
+  alias PhxJsonRpc.Router.Middleware
+  alias PhxJsonRpc.Error.InternalError
+  alias PhxJsonRpc.{Request, Response}
+  alias PhxJsonRpcWeb.{TestController, TestMiddleware}
+
+  use PhxJsonRpc.Router,
+    otp_app: :test_rpc,
+    schema: "test/priv/static/openrpc.json",
+    version: "2.0",
+    max_batch_size: 20
+
+  middleware([TestMiddleware])
+
+  rpc("hello", TestController, :hello, "#/components/schemas/Name")
+
+  test "request passes through middleware" do
+    request = %{
+      "jsonrpc" => "2.0",
+      "method" => "hello",
+      "params" => %{"name" => "Ron"},
+      "id" => "ID"
+    }
+
+    assert handle(request, %{test: true}) == %Response{
+             version: "2.0",
+             data: "Hello, Ron",
+             id: "ID",
+             valid?: true
+           }
+  end
+
+  test "request doen't pass middleware" do
+    request = %{
+      "jsonrpc" => "2.0",
+      "method" => "hello",
+      "params" => %{"name" => "Ron"},
+      "id" => "ID"
+    }
+
+    expected_error = %InternalError{message: "** (RuntimeError) Test not passed"}
+
+    assert handle(request, %{test: false}) == %Response{
+             version: "2.0",
+             data: nil,
+             id: "ID",
+             valid?: false,
+             error: expected_error
+           }
+  end
+end

--- a/test/phx_json_rpc/router/context_test.exs
+++ b/test/phx_json_rpc/router/context_test.exs
@@ -1,0 +1,4 @@
+defmodule PhxJsonRpc.Router.ContextTest do
+  use ExUnit.Case
+  doctest PhxJsonRpc.Router.Context
+end

--- a/test/phx_json_rpc_web/middleware/test_middleware.ex
+++ b/test/phx_json_rpc_web/middleware/test_middleware.ex
@@ -1,0 +1,12 @@
+defmodule PhxJsonRpcWeb.TestMiddleware do
+  @moduledoc false
+  use PhxJsonRpc.Router.Middleware
+
+  def handle(request, context) do
+    if context.meta_data.test do
+      request
+    else
+      raise "Test not passed"
+    end
+  end
+end


### PR DESCRIPTION
## Added

- Middleware interface and macro (handles requests before dispatching to the rpc controller)

### Changed

- `Router.handle` now accepts second optional parameter: `meta_data`
- Bump credo from 1.6.7 to 1.7.0
- Bump dialyxir from 1.2.0 to 1.3.0
- Bump excoveralls from 0.15.0 to 0.16.1
- Bump ex_doc from 0.29.0 to 0.29.4